### PR TITLE
Compile external scanner for rust binding

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -9,23 +9,9 @@ fn main() {
         .flag_if_supported("-Wno-trigraphs");
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
-
-    // If your language uses an external scanner written in C,
-    // then include this block of code:
-
-    /*
-    let scanner_path = src_dir.join("scanner.c");
-    c_config.file(&scanner_path);
-    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
-
     c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 
-    // If your language uses an external scanner written in C++,
-    // then include this block of code:
-
-    /*
     let mut cpp_config = cc::Build::new();
     cpp_config.cpp(true);
     cpp_config.include(&src_dir);
@@ -36,5 +22,4 @@ fn main() {
     cpp_config.file(&scanner_path);
     cpp_config.compile("scanner");
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 }


### PR DESCRIPTION
This change allows you to pull this parser in as a dependency in a rust project.