### PR TITLE
Fix Clippy lints

### DIFF
--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -31,14 +31,14 @@ pub fn language() -> Language {
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
-pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
 // Uncomment these to include any queries that this grammar contains
 
-pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
-// pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
-pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
-pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
+pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
+// pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
+pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
+pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
While using this parser as a Rust crate in a larger tree-sitter project that I'm working on, I noticed that it was failing several Clippy lints for having [redundant static lifetimes](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_static_lifetimes):
```
PS C:\Users\alexs\projects\tree-sitter-racket> cargo clippy
   Compiling tree-sitter-racket v0.3.0 (C:\Users\alexs\projects\tree-sitter-racket)
warning: constants have by default a `'static` lifetime
  --> bindings/rust/lib.rs:34:24
   |
34 | pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
   |                       -^^^^^^^---- help: consider removing `'static`: `&str`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_static_lifetimes
   = note: `#[warn(clippy::redundant_static_lifetimes)]` on by default

warning: constants have by default a `'static` lifetime
  --> bindings/rust/lib.rs:38:30
   |
38 | pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
   |                             -^^^^^^^---- help: consider removing `'static`: `&str`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_static_lifetimes

warning: constants have by default a `'static` lifetime
  --> bindings/rust/lib.rs:40:26
   |
40 | pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
   |                         -^^^^^^^---- help: consider removing `'static`: `&str`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_static_lifetimes

warning: constants have by default a `'static` lifetime
  --> bindings/rust/lib.rs:41:24
   |
41 | pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
   |                       -^^^^^^^---- help: consider removing `'static`: `&str`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_static_lifetimes

warning: `tree-sitter-racket` (lib) generated 4 warnings (run `cargo clippy --fix --lib -p tree-sitter-racket` to apply 4 suggestions)
    Finished dev [unoptimized + debuginfo] target(s) in 0.91s
PS C:\Users\alexs\projects\tree-sitter-racket>
```
This pull request makes the recommended edits. I compared the build artifacts and found that the change resulted in no differences between the binaries.