### PR TITLE
Avoid using unavailable functions when compiling to wasm

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -19,8 +19,10 @@ typedef struct {
 
 static void check_alloc(void *ptr) {
     if (ptr == NULL) {
-        fprintf(stderr, "Scanner: Failed to allocate memory\n");
-        exit(EXIT_FAILURE);
+        #ifndef __wasm32__
+            fprintf(stderr, "Scanner: Failed to allocate memory\n");
+        #endif
+        abort();
     }
 }
 


### PR DESCRIPTION
When compiling tree-sitter parsers to WASM, `abort` is currently available, but `exit` is not. Also, `fwrite` is not available, so we guard the `fprintf` call with an `ifndef`.